### PR TITLE
Fixed constant Xcode crash on startup.

### DIFF
--- a/KFCocoaPodsPlugin/Sources/Controllers/KFCocoaPodController.m
+++ b/KFCocoaPodsPlugin/Sources/Controllers/KFCocoaPodController.m
@@ -84,15 +84,24 @@ NSString * const KFBuildVersion = @"buildVersion";
         
         if (error == nil)
         {
-            NSString *version = yaml[0][@"version"];
-            NSArray *versionComponents = [version componentsSeparatedByString:@"."];
-            if ([versionComponents count] == 3)
+            NSDictionary *versionDictionary = yaml[0];
+            
+            if(![versionDictionary isKindOfClass:[NSDictionary class]])
             {
-                versionBlock(@{KFMajorVersion: versionComponents[0], KFMinorVersion: versionComponents[1], KFBuildVersion: versionComponents[2]});
+                versionBlock(nil);
             }
             else
             {
-                versionBlock(nil);
+                NSString *version = versionDictionary[@"version"];
+                NSArray *versionComponents = [version componentsSeparatedByString:@"."];
+                if ([versionComponents count] == 3)
+                {
+                    versionBlock(@{KFMajorVersion: versionComponents[0], KFMinorVersion: versionComponents[1], KFBuildVersion: versionComponents[2]});
+                }
+                else
+                {
+                    versionBlock(nil);
+                }
             }
         }
         else


### PR DESCRIPTION
The problem is rvm. If I "whereis pod" there is nothing. Another thing is that in `- (void)cocoaPodsVersion:(KFCocoaPodsVersionBlock)versionBlock` serialized yaml looks like this:

```
<__NSArrayM 0x600000053260>(
.bashrc
)
```

And then, without any checks we are trying to get version `NSString *version = yaml[0][@"version"];`, but `yaml[0]` is type of NSString and not NSDictionary. 
